### PR TITLE
Refactor : LoginInput 스타일 수정

### DIFF
--- a/src/components/FormCard.tsx
+++ b/src/components/FormCard.tsx
@@ -1,3 +1,4 @@
+import { flexCenter } from '@/styles/common.style';
 import { PropsWithChildren } from 'react';
 
 interface FormCardProps extends PropsWithChildren {
@@ -19,16 +20,18 @@ const FormCard: React.FC<FormCardProps> = ({ children, label, size }) => {
   };
 
   return (
-    <>
+    <div
+      className={`${flexCenter} flex items-center justify-center grid justify-items-start`}
+    >
       <div
-        className={`bg-violet rounded-t-lg text-white text-2xl font-extrabold text-center pt-[8px] ml-[30px] w-[240px] h-[48px] `}
+        className={`bg-violet rounded-t-xl text-white text-2xl font-extrabold text-center pt-[8px] ml-[30px] w-[240px] h-[48px] `}
       >
         {label}
       </div>
-      <div className={`${sizeCSS[size]} bg-background rounded-lg`}>
+      <div className={`${sizeCSS[size]} bg-backgroundGrey rounded-xl`}>
         {children}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/LoginInput.tsx
+++ b/src/components/LoginInput.tsx
@@ -5,33 +5,46 @@ import { InputHTMLAttributes } from 'react';
  */
 interface LoginInputProps
   extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  bgColor: 'gray' | 'white'; //input의 배경색입니다.
   size: 'small' | 'large' | 'full'; //input의 크기 옵션입니다. 'small', 'large', 'full' 중 하나를 선택합니다.
-  placeholderTxt: string; //input 태그의 placeholder에 들어갈 문자열입니다.
+  label: string; //input 태그의 label에 들어갈 문자열입니다.
 }
 
 /**
  * 로그인 form에서 사용하는 input 컴포넌트입니다.
 
  * // 사용 예시:
- * <LoginInput placeholderTxt="아이디" size="small" />
+ * <LoginInput bgColor="white" size="large" label="아이디" />
  */
 const LoginInput: React.FC<LoginInputProps> = ({
-  placeholderTxt,
+  label,
+  bgColor,
   size,
   ...rest
 }) => {
+  const bgColorCSS = {
+    gray: `bg-backgroundGrey`,
+    white: `bg-white`,
+  };
+
   const sizeCSS = {
-    small: 'w-[288px] h-[36px]',
-    large: 'w-[380px] h-[44px]',
-    full: 'w-full h-[60px]',
+    small: { box: 'w-[320px] h-[44px]', input: 'w-[220px] h-[42px]' },
+    large: { box: 'w-[380px] h-[44px]', input: 'w-[308px] h-[42px]' },
+    full: { box: 'w-full h-[44px]', input: 'w-full h-[42px]' },
   };
 
   return (
-    <input
-      {...rest}
-      className={` ${sizeCSS[size]} border-b border-b-2 border-darkGrey font-extrabold text-lg outline-none`}
-      placeholder={placeholderTxt}
-    />
+    <div
+      className={`${bgColorCSS[bgColor]} ${sizeCSS[size].box} border-b-[2px] border-darkGrey flex`}
+    >
+      <label className="font-extrabold text-lg text-darkGrey mt-[8px] mr-[16px] justify-start">
+        {label}
+      </label>
+      <input
+        {...rest}
+        className={`${bgColorCSS[bgColor]} ${sizeCSS[size].input}  font-extrabold text-lg outline-none justify-end`}
+      />
+    </div>
   );
 };
 

--- a/src/styles/common.style.ts
+++ b/src/styles/common.style.ts
@@ -1,0 +1,1 @@
+export const flexCenter: string = 'flex flex-col items-center justify-center';


### PR DESCRIPTION
#### 📝 작업 상세 내용 (css 작업 시 이미지 첨부)
- LoginInput에서 기존 placeholder에서 label형태로 props를 전달 받도록 수정했습니다
- 정상적으로 밑줄이 나오게 수정했습니다
- display flex center관련 로직이 자주 사용 되는 거 같아 src/style/common.style.ts에 상수화 시켰습니다

<img src="https://github.com/MOBI-BattleTalk/BattleTalk/assets/134574485/92d78329-b3d5-4398-ba8f-495b9b869ba0"/>

#### ✅ 다음 할 일
- LoginPage 퍼블리싱

#### ？ 질문 사항
