### PR TITLE
Feat : MainPage data get요청

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -1,10 +1,10 @@
-import {axiosInstance} from '@/apis/core.ts';
+import { axiosInstance } from '@/apis/core.ts';
 import cookieStorage from '@/utils/cookieStorage.tsx';
-import {AxiosResponse} from 'axios';
+import { AxiosResponse } from 'axios';
 import LocalStorage from '@/utils/localStorage.tsx';
-import {nickNameType, SignInType, SignUpType} from '@/types/userType';
-import {ACCESS_TOKEN, STORAGE_KEYS} from '@/const/Keys.ts';
-import {END_POINTS} from '@/const/EndPoint.ts';
+import { nickNameType, SignInType, SignUpType } from '@/types/userType';
+import { ACCESS_TOKEN, STORAGE_KEYS } from '@/const/Keys.ts';
+import { END_POINTS } from '@/const/EndPoint.ts';
 
 //로그인시 받아오는 데이터 타입
 type SignInDataType = {
@@ -68,7 +68,6 @@ const AuthApi = {
   },
   //프로필 사진 변경
   patchUpdateProfile: async (data: FormData) => {
-    console.log('profile', data);
     const res = await axiosInstance.patch(END_POINTS.UPDATE_PROFILE, data);
     return res.data;
   },

--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -1,6 +1,6 @@
-import type {GetBattleInfoType, PostCommentType} from '@/types/postType';
-import {axiosInstance} from './core';
-import {END_POINTS} from '@/const/EndPoint'; // BattleApi.ts
+import type { GetBattleInfoType, PostCommentType } from '@/types/postType';
+import { axiosInstance } from './core';
+import { END_POINTS } from '@/const/EndPoint'; // BattleApi.ts
 
 // BattleApi.ts
 const BattleApi = {
@@ -9,15 +9,22 @@ const BattleApi = {
     const res = await axiosInstance.post(END_POINTS.POST, data);
     return res;
   },
-  //posData get api 요청
+  // posData get api 요청
   getBattleInfo: async () => {
     const res = await axiosInstance.get<GetBattleInfoType>(END_POINTS.POST);
     return res.data;
   },
+  // 무한 스크롤 구현을 위해 주석 처리 해놓았습니다.
+  // getBattleInfo: async (pageParam: unknown) => {
+  //   const res = await axiosInstance.get<GetBattleInfoType>(
+  //     END_POINTS.POST + `&page=${pageParam}`,
+  //   );
+  //   return res.data;
+  // },
+
   //배틀 참여하기 api 요청(BattleJoinModal)s
   postComment: async (data: PostCommentType) => {
     const res = await axiosInstance.post(END_POINTS.COMMENT, data);
-    console.log('aaa', res);
     return res;
   },
 };

--- a/src/components/BasicModal.tsx
+++ b/src/components/BasicModal.tsx
@@ -61,7 +61,9 @@ const BasicModal: React.FC<ModalProps> = ({
             <AlertDialogAction onClick={func}>삭제</AlertDialogAction>
           </div>
         )}
-        {modalType === 'alert' && <AlertDialogAction>확인</AlertDialogAction>}
+        {modalType === 'alert' && (
+          <AlertDialogAction onClick={func}>확인</AlertDialogAction>
+        )}
       </AlertDialogFooter>
     </AlertDialogContent>
   );

--- a/src/components/ProfileModal.tsx
+++ b/src/components/ProfileModal.tsx
@@ -69,17 +69,14 @@ const ProfileModal = () => {
     //   formData.append('image', '');
     // }
     // console.log(event.target.profile.files![0]);
-    const updateInfoRes = await AuthApi.patchUserNickName({
+    await AuthApi.patchUserNickName({
       nickName: event.target.nickName.value,
     });
-    console.log(updateInfoRes);
-
     userInfo.nickName = event.target.nickName.value;
     //userInfo 를 다시 stirngfy 해서 넣기
     //닉네임만 수정
     //JSON.stringfy(data)
     LocalStorage.setItem(STORAGE_KEYS.USER_INFO, JSON.stringify(userInfo));
-    console.log('바뀐 유저 데이터', JSON.stringify(userInfo));
 
     // const updateProfile = await AuthApi.patchUpdateProfile(formData);
     // console.log(updateProfile);

--- a/src/components/ResultBar.tsx
+++ b/src/components/ResultBar.tsx
@@ -13,10 +13,22 @@ interface Props {
 
 const ResultBar: React.FC<Props> = ({ type, redCount, blueCount }) => {
   const total = redCount + blueCount;
+
   //100%중 빨간 옵션의 선택 비율
-  const redRatio = Math.round((redCount / total) * 100);
+  let redRatio;
+  if (redCount === 0) {
+    redRatio = 0;
+  } else {
+    redRatio = Math.round((redCount / total) * 100);
+  }
+
   //100%중 파란 옵션의 선택 비율
-  const blueRatio = 100 - redRatio;
+  let blueRatio;
+  if (redCount === 0) {
+    blueRatio = 0;
+  } else {
+    blueRatio = 100 - redRatio;
+  }
 
   const redTextColor = redRatio > blueRatio ? 'text-deepRed' : 'text-red';
   const blueTextColor = redRatio < blueRatio ? 'text-deepBlue' : 'text-blue';

--- a/src/components/ResultCss.ts
+++ b/src/components/ResultCss.ts
@@ -3,6 +3,7 @@ type ResultCssType = {
 };
 
 export const SmallWidthCSS: ResultCssType = {
+  0: 'w-[1px]',
   1: 'w-[1.5px]',
   2: 'w-[3px]',
   3: 'w-[4.5px]',
@@ -106,6 +107,7 @@ export const SmallWidthCSS: ResultCssType = {
 };
 
 export const MediumWidthCSS: ResultCssType = {
+  0: 'w-[1px]',
   1: 'w-[2.5px]',
   2: 'w-[5px]',
   3: 'w-[7.5px]',
@@ -209,6 +211,7 @@ export const MediumWidthCSS: ResultCssType = {
 };
 
 export const LargeWidthCSS: ResultCssType = {
+  0: 'w-[1px]',
   1: 'w-[3px]',
   2: 'w-[6px]',
   3: 'w-[9px]',

--- a/src/const/EndPoint.ts
+++ b/src/const/EndPoint.ts
@@ -5,8 +5,8 @@
  * */
 
 export const END_POINTS = {
-  POST: '/data/post',
-  DETAIL_POST: '/data/detail/post',
+  POST: '/data/battle',
+  DETAIL_POST: '/data/detail/battle',
   COMMENT: '/data/comment',
   USER_SIGN_UP: '/user/sign-up',
   USER_SIGN_IN: '/user/sign-in',

--- a/src/const/queryKey.ts
+++ b/src/const/queryKey.ts
@@ -1,0 +1,3 @@
+export const BATTLE_QUERY_KEY = {
+  BATTLE_LISt: 'battleList',
+};

--- a/src/pages/CreateBattlePage/components/CreateForm.tsx
+++ b/src/pages/CreateBattlePage/components/CreateForm.tsx
@@ -64,7 +64,6 @@ const CreateForm: React.FC = () => {
     formData.append('redVoteCount', '0');
     formData.append('voteTotalCount', '0');
     await BattleApi.postCreateBattle(formData);
-    navigate(END_POINTS.HOME);
   };
 
   // 모달 유형 입니다.
@@ -90,7 +89,12 @@ const CreateForm: React.FC = () => {
         onOptionImgChange={onOptionImgChange}
       />
       <div className="mt-[50px]">
-        <BasicModal {...successModalProp} func={() => {}} />
+        <BasicModal
+          {...successModalProp}
+          func={() => {
+            navigate(END_POINTS.HOME);
+          }}
+        />
         <AlertDialogTrigger asChild>
           <Button
             bgColor="gray"

--- a/src/pages/DetailPage/components/BattleJoinModal.tsx
+++ b/src/pages/DetailPage/components/BattleJoinModal.tsx
@@ -56,11 +56,9 @@ const BattleJoinModal: React.FC<Props> = ({ post }) => {
       parentId: post.id,
     };
 
-    console.log(CommentData);
     //댓글 작성 성공 여부에 따라 다른 토스트 메세지를 보여줍니다.
     try {
-      const res = await BattleApi.postComment(CommentData);
-      console.log(res);
+      await BattleApi.postComment(CommentData);
       toastMessage.commentSuccessNotify();
     } catch (err) {
       toastMessage.commentFailureNotify();

--- a/src/pages/MainPage/components/BattleHeader.tsx
+++ b/src/pages/MainPage/components/BattleHeader.tsx
@@ -22,6 +22,7 @@ const BattleHeader: React.FC<Props> = ({
           imgUrl={profileUrl || DefaultImg}
           size={'tiny'}
           imageShape={'rounded'}
+          clickColor="none"
         />
         <div>{nickName}</div>
         <div className="text-commonGrey">{timeHelper(createdAt)}</div>

--- a/src/pages/MainPage/components/MainBattleCard.tsx
+++ b/src/pages/MainPage/components/MainBattleCard.tsx
@@ -2,17 +2,40 @@ import ResultBar from '@/components/ResultBar.tsx';
 import ImageBox from '@/components/ImageBox.tsx';
 import BattleHeader from '@/pages/MainPage/components/BattleHeader.tsx';
 import { useNavigate } from 'react-router-dom';
-import { GetBattleInfoType } from '@/types/postType.ts';
 
 interface Props {
-  post: GetBattleInfoType;
+  createAt: string;
+  nickName: string;
+  profileUrl: string;
+  title: string;
+  blueOptionTitle: string;
+  redOptionTitle: string;
+  blueVoteCount: string;
+  redVoteCount: string;
+  voteTotalCount: string;
+  blueOptionImg: string;
+  redOptionImg: string;
+  postId: string;
 }
 
-const MainBattleCard: React.FC<Props> = ({ post }) => {
+const MainBattleCard: React.FC<Props> = ({
+  createAt,
+  nickName,
+  profileUrl,
+  title,
+  blueOptionTitle,
+  redOptionTitle,
+  blueVoteCount,
+  redVoteCount,
+  voteTotalCount,
+  blueOptionImg,
+  redOptionImg,
+  postId,
+}) => {
   const navigate = useNavigate();
 
   const onMovePostId = () => {
-    navigate(`/detail/${post.id}`);
+    navigate(`/detail/${postId}`);
   };
 
   return (
@@ -22,46 +45,58 @@ const MainBattleCard: React.FC<Props> = ({ post }) => {
              flex-col hover: cursor-pointer"
     >
       <BattleHeader
-        nickName={post.data.nickName}
-        profileUrl={post.data.profileUrl}
-        totalCount={post.data.voteTotalCount}
-        createdAt={post.createAt}
+        nickName={nickName}
+        profileUrl={profileUrl}
+        totalCount={voteTotalCount}
+        createdAt={createAt}
       />
       <div className="text-center text-lg mt-[10px]">
-        {post.data.title} <br />
+        {title} <br />
         <div className="flex gap-[10px] justify-center text-[18px]">
-          <span className="text-deepBlue">{post.data.blueOptionTitle}</span>
+          <span className="text-blue">{blueOptionTitle}</span>
           <span className="">vs</span>
-          <span className="text-deepRed"> {post.data.redOptionTitle}</span>
+          <span className="text-red"> {redOptionTitle}</span>
         </div>
       </div>
       {/*사이즈에 따라 Result 바가 다릅니다.*/}
       <div className="flex items-center justify-center">
         <div className="block md:hidden p-[20px]">
-          <ResultBar redCount={13} blueCount={26} type="small" />
+          <ResultBar
+            redCount={Number(redVoteCount)}
+            blueCount={Number(blueVoteCount)}
+            type="small"
+          />
         </div>
       </div>
       <div className="flex gap-[10px] align-center justify-center">
         <div className="flex align-center flex-col text-center">
           <ImageBox
             clickColor={'none'}
-            imgUrl={post.dataImage[0].url}
+            imgUrl={blueOptionImg}
             size={'smallest'}
             imageShape={'square'}
           />
         </div>
         {/*사이즈에 따라 Result 바가 다릅니다.*/}
         <div className="align-center flex-col text-center hidden xl:block mt-[40px]">
-          <ResultBar redCount={13} blueCount={26} type="medium" />
+          <ResultBar
+            redCount={Number(redVoteCount)}
+            blueCount={Number(blueVoteCount)}
+            type="medium"
+          />
         </div>
         {/*사이즈에 따라 Result 바가 다릅니다.*/}
         <div className="hidden md:block lg:block xl:hidden mt-[40px]">
-          <ResultBar redCount={13} blueCount={26} type="small" />
+          <ResultBar
+            redCount={Number(redVoteCount)}
+            blueCount={Number(blueVoteCount)}
+            type="small"
+          />
         </div>
         <div className="flex align-center flex-col text-center pb-[20px]">
           <ImageBox
             clickColor={'none'}
-            imgUrl={post.dataImage[1].url}
+            imgUrl={redOptionImg}
             size={'smallest'}
             imageShape={'square'}
           />

--- a/src/pages/MainPage/index.tsx
+++ b/src/pages/MainPage/index.tsx
@@ -1,13 +1,65 @@
 import MainBattleCard from '@/pages/MainPage/components/MainBattleCard.tsx';
-import { BattleMockList } from '@/mock/postMock.ts';
+// import { BattleMockList } from '@/mock/postMock.ts';
+import BattleApi from '@/apis/post';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { BATTLE_QUERY_KEY } from '@/const/queryKey';
 
 const MainPage = () => {
+  const { data: battleData, fetchNextPage } = useInfiniteQuery({
+    queryKey: [BATTLE_QUERY_KEY.BATTLE_LISt],
+    queryFn: BattleApi.getBattleInfo,
+    // 무한 스크롤 구현을 위한 주석 처리 입니다.
+    // queryFn: ({ pageParam = 0 }) => BattleApi.getBattleInfo(pageParam),
+    initialPageParam: 0,
+    getNextPageParam: (lastPage) => {
+      return (
+        lastPage.pageNation.current < lastPage.pageNation.end &&
+        lastPage.pageNation.current + 1
+      );
+    },
+  });
+
+  const battleList =
+    battleData && Object.values(battleData.pages[0]).slice(0, -1);
+
   return (
-    <div className={'flex gap-[30px] flex-col pb-[50px]'}>
-      {BattleMockList.map((post, index) => {
-        return <MainBattleCard post={post} key={index} />;
-      })}
-    </div>
+    battleList && (
+      <div className={'flex gap-[30px] flex-col pb-[50px]'}>
+        {battleList.map((post, index) => {
+          const createAt = post?.createdAt;
+          const {
+            nickName,
+            profileUrl,
+            title,
+            blueOptionTitle,
+            redOptionTitle,
+            blueVoteCount,
+            redVoteCount,
+            voteTotalCount,
+          } = post?.data;
+          const blueOptionImg = post.dataImage[0].url;
+          const redOptionImg = post.dataImage[1].url;
+          const postId = post.id;
+          return (
+            <MainBattleCard
+              key={index}
+              createAt={createAt}
+              nickName={nickName}
+              profileUrl={profileUrl}
+              title={title}
+              blueOptionTitle={blueOptionTitle}
+              redOptionTitle={redOptionTitle}
+              blueVoteCount={blueVoteCount}
+              redVoteCount={redVoteCount}
+              voteTotalCount={voteTotalCount}
+              blueOptionImg={blueOptionImg}
+              redOptionImg={redOptionImg}
+              postId={postId}
+            />
+          );
+        })}
+      </div>
+    )
   );
 };
 

--- a/src/types/postType.ts
+++ b/src/types/postType.ts
@@ -24,7 +24,7 @@ export type GetBattleInfoType = {
     voteTotalCount: string;
   };
   id: string;
-  createAt: string;
+  createdAt: string;
   dataImage: { url: string }[];
   dataUser: null;
 };


### PR DESCRIPTION
#### 📝 작업 상세 내용 (css 작업 시 이미지 첨부)
- 현재 백엔드 delete 요청이 안되서 잘못된 데이터를 지울 수 없었습니다
  그래서 기존 /data/post url에서 /data/battle url로 데이터 주소를 바꾸고 새롭게 추가했습니다.

- 백엔드에서 받아온 데이터가 배열형태로 오지않아 map()을 사용할 수 없어 ,배열로 바꾸는 로직이 있습니다.
![image](https://github.com/MOBI-BattleTalk/BattleTalk/assets/134574485/45334147-d427-4f1f-8d13-7162821349ec)
![image](https://github.com/MOBI-BattleTalk/BattleTalk/assets/134574485/ebd276e8-48c0-4213-b6e4-dff64d036539)

- 위와 같은 이유 + useInfiniteQuery를 활용하여 데이터 요청 url에 page값을 주었을 때 post로 추가 한 데이터들이 오지 않아 무한 스크롤은 구현 하지 못했습니다.

- react-query 사용시 쿼리 키에 들어갈 문자열을 상수화 하기위해 src/const/queryKey.ts에 저장했습니다.
![image](https://github.com/MOBI-BattleTalk/BattleTalk/assets/134574485/2b0d3a9d-65a6-4092-8a31-731b87f1af49)

- 코드 전역에 존재하는 console.log()를 삭제 했습니다.

#### ✅ 다음 할 일
- detailPage 기능 구현

#### ？ 질문 사항
