### PR TITLE
Feat : 댓글 인피니티 스크롤 구현 

### DIFF
--- a/src/apis/post.ts
+++ b/src/apis/post.ts
@@ -1,5 +1,5 @@
-import type {GetCommentType, GetDetailBattleInfoType, PatchVoteCountType, PostCommentType,} from '@/types/postType';
-import {GetBattleListWithPagination} from '@/types/postType'; // BattleApi.ts
+import type {GetDetailBattleInfoType, PatchVoteCountType, PostCommentType,} from '@/types/postType';
+import {GetBattleListWithPagination, GetCommentListWithPagination,} from '@/types/postType'; // BattleApi.ts
 import {axiosInstance} from './core';
 import {END_POINTS} from '@/const/EndPoint';
 
@@ -14,6 +14,7 @@ const BattleApi = {
     });
     return res;
   },
+  //배틀 리스트 가져오기
   getBattleInfo: async (pageParam: number) => {
     const res = await axiosInstance.get<GetBattleListWithPagination>(
       END_POINTS.POST + `?page=${pageParam}`,
@@ -52,10 +53,18 @@ const BattleApi = {
     const res = await axiosInstance.post(END_POINTS.COMMENT, data);
     return res;
   },
-  // 댓글 불러오기 api 요청
-  getComment: async () => {
-    const res = await axiosInstance.get<GetCommentType>(END_POINTS.COMMENT);
-    console.log('aaaaaa', res);
+  // 댓글 불러오기 요청
+  getComment: async ({
+    pageParam,
+    parentId,
+  }: {
+    pageParam: number;
+    parentId: string;
+  }) => {
+    const res = await axiosInstance.get<GetCommentListWithPagination>(
+      END_POINTS.COMMENT + `?page=${pageParam}&parentId=${parentId}`,
+    );
+    console.log('댓글 불러오기', res);
     return res.data;
   },
   // 댓글 불러오기 api 요청

--- a/src/pages/DetailPage/components/CommentBox.tsx
+++ b/src/pages/DetailPage/components/CommentBox.tsx
@@ -14,6 +14,8 @@ const CommentBox: React.FC<Props> = ({ comment, colorType }) => {
   //const userInfo = useRecoilValue(userInfoAtom);
   const borderColor =
     colorType === 'blue' ? 'border-lineSkyblue' : 'border-linePink';
+
+  //내 댓글 삭제가 되는 기능 주석 처리하였습니다.
   // const deleteModalProps = MODAL.DELETE_COMMENT;
 
   // const onClickComment = async () => {
@@ -27,11 +29,10 @@ const CommentBox: React.FC<Props> = ({ comment, colorType }) => {
   //   }
   // };
 
-  //내 댓글 삭제가 되는 기능 주석 처리하였습니다.
   //const isMyComment = comment.data.userId === userInfo?.userId;
   return (
     <div
-      className={`border-[3px] p-[10px] ${borderColor} rounded-[10px] w-[450px] md:w-[380px] lg:w-[460px] relative`}
+      className={`border-[3px] p-[10px] ${borderColor} rounded-[10px] w-[450px] md:w-[380px] lg:w-[460px] relative mt-[10px]`}
     >
       <div className="flex w-[40px] items-center justify-between">
         <div className="flex items-center">

--- a/src/pages/DetailPage/components/CommentList.tsx
+++ b/src/pages/DetailPage/components/CommentList.tsx
@@ -1,8 +1,8 @@
 import ColorCommentList from '@/pages/DetailPage/components/ColorCommentList.tsx';
-import { GetCommentArrType } from '@/types/postType';
+import { CommentListType } from '@/types/postType';
 
 type CommentListProps = {
-  postCommentListArr: GetCommentArrType[];
+  postCommentListArr: CommentListType[];
   battlePostId: string | undefined;
 };
 
@@ -16,7 +16,7 @@ const CommentList: React.FC<CommentListProps> = ({ postCommentListArr }) => {
   );
 
   return (
-    <div className="flex-col items-center md:flex-row flex w-[600px] gap-[20px] flex-wrap md:justify-between mt-[20px] pb-[30px] md:w-[800px] lg:w-[1000px] justify-center">
+    <div className="flex-col items-center md:flex-row flex w-[600px] gap-[20px] flex-wrap md:justify-between mt-[20px] pb-[30px] md:w-[800px] lg:w-[1000px] justify-center md:items-start">
       <ColorCommentList commentList={blueData} colorType="blue" />
       <ColorCommentList commentList={redData} colorType="red" />
     </div>

--- a/src/pages/DetailPage/index.tsx
+++ b/src/pages/DetailPage/index.tsx
@@ -1,13 +1,17 @@
-import DetailBattleCard from '@/pages/DetailPage/components/DetailBattleCard.tsx';
-import CommentList from '@/pages/DetailPage/components/CommentList.tsx';
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import BattleApi from '@/apis/post';
 import { BATTLE_QUERY_KEY } from '@/const/queryKey';
 import { useParams } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { userInfoAtom } from '@/atom/user.ts';
+import { useObserver } from '@/hooks/useObserver.tsx';
+import { useRef } from 'react';
+import DetailBattleCard from '@/pages/DetailPage/components/DetailBattleCard.tsx';
+import CommentList from '@/pages/DetailPage/components/CommentList.tsx';
+import { CommentListType } from '@/types/postType.ts';
 
 const DetailPage = () => {
+  const bottom = useRef(null);
   // 현재 상세페이지에  id
   const { id: battlePostId } = useParams();
   const userInfo = useRecoilValue(userInfoAtom);
@@ -17,19 +21,46 @@ const DetailPage = () => {
     queryFn: () => BattleApi.getDetailBattleInfo(battlePostId!),
   });
 
-  // 댓글 정보
-  const { data: commentList } = useQuery({
+  //댓글을 인피니티 스크롤로 불러옵니다.
+  const {
+    data: commentList,
+    fetchNextPage, //다음 페이지를 불러오는 함수
+    isSuccess: isCommentSuccess,
+  } = useInfiniteQuery({
     queryKey: [BATTLE_QUERY_KEY.COMMENT_LIST, battlePostId],
-    queryFn: BattleApi.getComment,
+    queryFn: async ({ pageParam }) => {
+      return await BattleApi.getComment({ pageParam, parentId: battlePostId! });
+    },
+    initialPageParam: 1,
+    //다음 페이지를 불러옵니다.
+    getNextPageParam: (lastPage) => {
+      const page = lastPage.pageNation.current;
+      if (lastPage.pageNation.total === page) return;
+      return page + 1;
+    },
   });
 
-  const commentListArr = commentList && Object.values(commentList).slice(0, -1);
-  const postCommentListArr =
-    commentListArr &&
-    commentListArr.filter((comment) => comment.data.parentId === battlePostId);
+  //useObserver로 넘겨줄 콜백, entry로 넘어오는 것이 isIntersecting이면 fetchNextPage가 실행
+  const onIntersect = ([entry]: IntersectionObserverEntry[]) =>
+    entry.isIntersecting && fetchNextPage();
+
+  //useObserver 훅함수
+  useObserver({
+    target: bottom,
+    onIntersect,
+    threshold: 0.5,
+  });
+
+  //댓글 데이터를 가져와서 가공후 한번에 댓글 배열(commentListArr)에 넣었습니다.
+  const commentListArr: CommentListType[] = [];
+  commentList?.pages.map((page) => {
+    console.log('page', page);
+    const pageResult = Object.values(page).slice(0, -1) as CommentListType[];
+    commentListArr.push(...pageResult);
+  });
 
   //내 댓글이 이미 존재하는지 여부
-  const hasMyComment = postCommentListArr?.some(
+  const hasMyComment = commentListArr?.some(
     (comment) => comment.data.userId === userInfo?.userId,
   );
 
@@ -46,13 +77,14 @@ const DetailPage = () => {
         />
       )}
       <div className="mb-[60px]">
-        {postCommentListArr && (
+        {commentListArr && isCommentSuccess && (
           <CommentList
-            postCommentListArr={postCommentListArr!}
+            postCommentListArr={commentListArr!}
             battlePostId={battlePostId}
           />
         )}
       </div>
+      <div ref={bottom}></div>
     </div>
   );
 };

--- a/src/types/postType.ts
+++ b/src/types/postType.ts
@@ -42,6 +42,11 @@ export type GetBattleListWithPagination = {
   pageNation: TPageNation;
 };
 
+export type GetCommentListWithPagination = {
+  [key: number]: CommentListType;
+  pageNation: TPageNation;
+};
+
 export type GetDetailBattleInfoType = {
   data: {
     data: {


### PR DESCRIPTION
### PR 템플릿입니다.

#### 📝 작업 상세 내용 (css 작업 시 이미지 첨부)

- 댓글도 pagination이 적용되서 데이터가 오는 관계로
포스트와 같은 인피니티 스크롤 기능을 구현해서 적용하였습니다. 
- 만들어 놓은 useObserver 를 사용하였습니다. 
- 댓글의 쿼리키를 그대로 사용하였으며, api의 파람에 pageParam 을 추가하였습니다. 

#### ✅ 다음 할 일

#### ？ 질문 사항

- 다니엘님의 pr을 바로 머지했습니다. (머지 하기 전에 수정 상태 확인 후 다니엘님이 머지 했어야 했는데 죄송합니다..!!)해당 pr의 메세지를 확인해서 다시 pr 올려주시면 감사하겠습니다..!!